### PR TITLE
feat(docs): add umami analytics to the docs site

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -21,6 +21,16 @@ export default defineConfig({
         twitter: "https://x.com/weburz",
       },
       lastUpdated: true,
+      head: [
+        {
+          tag: "script",
+          attrs: {
+            async: true,
+            src: "https://analytics.weburz.com/script.js",
+            "data-website-id": "166f0328-f723-471b-86ec-48e85f284ed8",
+          },
+        },
+      ],
       sidebar: [
         {
           label: "Introduction",


### PR DESCRIPTION
### Summary
This PR integrates Umami analytics tracking into the Terox documentation site to monitor visitor engagement and page views.

Changes Made

- Added Umami tracking script to Starlight configuration in astro.config.mjs
- Configured analytics to load on all documentation pages
- Used Starlight's built-in head array for clean integration

 Technical Details

- Analytics script loads asynchronously to avoid impacting page performance
- Tracking is implemented via Starlight's native head injection mechanism
- No custom components required - leverages existing Starlight functionality