### PR TITLE
fix(docs): broken build social config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,3 +6,15 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
+
+  - repo: https://github.com/Weburz/crisp
+    rev: v1.0.0
+    hooks:
+      - id: crisp
+        name: lint git-commit messages
+
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v2.2.2
+    hooks:
+      - id: golangci-lint
+        name: lint Go source code

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -35,6 +35,7 @@ tasks:
     cmds:
       - task: install
       - task: docs:setup
+      - pre-commit install --install-hooks
 
   build:
     desc: Build the binary for the current system architecture.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -10,16 +10,48 @@ export default defineConfig({
       editLink: {
         baseUrl: "https://github.com/Weburz/terox/edit/main/docs",
       },
-      social: {
-        github: "https://github.com/Weburz/terox",
-        discord: "https://discord.gg/QeYqwyxBhR",
-        email: "mailto:contact@weburz.com",
-        facebook: "https://www.facebook.com/Weburz",
-        instagram: "https://www.instagram.com/weburzit",
-        linkedin: "https://www.linkedin.com/company/weburz",
-        youtube: "https://www.youtube.com/@Weburz",
-        twitter: "https://x.com/weburz",
-      },
+      social: [
+        {
+          icon: "github",
+          label: "GitHub",
+          href: "https://github.com/Weburz/terox",
+        },
+        {
+          icon: "discord",
+          label: "Discord",
+          href: "https://discord.gg/QeYqwyxBhR",
+        },
+        {
+          icon: "email",
+          label: "Email",
+          href: "mailto:contact@weburz.com",
+        },
+        {
+          icon: "facebook",
+          label: "Facebook",
+          href: "https://www.facebook.com/Weburz",
+        },
+        {
+          icon: "instagram",
+          label: "Instagram",
+          href: "https://www.instagram.com/weburzit",
+        },
+        {
+          icon: "linkedin",
+          label: "LinkedIn",
+          href: "https://www.linkedin.com/company/weburz",
+        },
+        {
+          icon: "youtube",
+          label: "YouTube",
+          href: "https://www.youtube.com/@Weburz",
+        },
+        {
+          icon: "x.com",
+          label: "Twitter",
+          href: "https://x.com/weburz",
+        },
+      ],
       lastUpdated: true,
       head: [
         {

--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+onlyBuiltDependencies:
+  - better-sqlite3
+  - esbuild
+  - sharp


### PR DESCRIPTION
The docs build was failing due to a breaking change in `@astrojs/starlight v0.33.0`, which changed the social config from an object to an array of link items. Updated `astro.config.mjs` to use the new array syntax with the correct icons, labels, and hrefs.

Also updated task setup to automatically run pre-commit install --install-hooks so contributors don't have to set up git hooks manually after cloning.