### PR TITLE
feat: support subpath template refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,24 @@ Terox will prompt you for the variables declared in the template's
 `terox.json`, render filenames and file contents, and write the result into
 `./my-project`.
 
-You can also scaffold straight from a public GitHub repository:
+You can also scaffold straight from a public GitHub repository. Weburz
+publishes its official templates as a single monorepo at
+[`weburz/terox-templates`](https://github.com/weburz/terox-templates) —
+each top-level directory is a template you can pick by appending its name
+to the repo ref:
 
 ```bash
-terox scaffold weburz/simple-website-template --output ./my-site
+terox scaffold weburz/terox-templates/npm-package --output ./my-package
 ```
+
+To see what's available without leaving the terminal:
+
+```bash
+terox list weburz/terox-templates
+```
+
+A bare `owner/repo` ref (no subpath) still works for single-template
+repositories like `weburz/simple-website-template`.
 
 For CI or scripted use, skip the prompts:
 
@@ -135,9 +148,9 @@ turning any GitHub repo into a quick `git clone` without the history.
 
 | Command   | What it does                                                           |
 | --------- | ---------------------------------------------------------------------- |
-| `scaffold <ref>` | Render a template into `--output`. `<ref>` is `owner/repo` or a local path. |
+| `scaffold <ref>` | Render a template into `--output`. `<ref>` is `owner/repo`, `owner/repo/subpath` (for template monorepos), or a local path. |
 | `create <name>`  | Write a starter template directory you can edit and publish.      |
-| `list`           | List templates cached locally.                                     |
+| `list [owner/repo]` | List templates cached locally, or browse the templates in a remote repository. |
 | `clean`          | Delete the local template cache.                                   |
 | `version`        | Print the build version.                                           |
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -2,8 +2,8 @@
  * Package cmd - The "cmd" package contains the logic to handle various
  * commands passed to the CLI tool.
  *
- * The "list" file in particular contains the logic to list all locally
- * available template(s) on disk.
+ * The "list" file in particular contains the logic to list templates,
+ * either from the local cache or from a remote GitHub repository.
  */
 package cmd
 
@@ -13,33 +13,40 @@ import (
 	"github.com/weburz/terox/internal/template"
 )
 
-var listCmdShortHelp = "List all locally available templates."
+var listCmdShortHelp = "List available templates (locally cached or in a remote repo)."
 
 var listCmdLongHelp = `
-List all the locally available templates.
+List available templates.
 
-This command will list all the available templates on your local system. The
-default directory, Terox will check of available templates is at
-"${XDG_DATA_HOME}/terox" wherein XDG_DATA_HOME is usually set to
-$HOME/.local/share.
+With no arguments, prints the templates already downloaded into the local
+cache at "${XDG_DATA_HOME}/terox" (typically $HOME/.local/share/terox).
+
+Given a GitHub repository ref of the form "owner/repo", prints the
+templates available at the root of that repository. Each top-level
+directory is treated as a candidate template; if a directory contains a
+terox.json with a "description" field, the description is shown next to
+the name.
 `
 
-var listExample = "terox list\nterox ls\nterox show"
+var listExample = `  terox list
+  terox list weburz/terox-templates
+  terox ls weburz/terox-templates`
 
-// Logic to handle the "list" command
 var listCmd = &cobra.Command{
-	Use:     "list",
+	Use:     "list [owner/repo]",
 	Aliases: []string{"ls", "show"},
 	Short:   listCmdShortHelp,
 	Example: listExample,
 	Long:    listCmdLongHelp,
-	Args:    cobra.NoArgs,
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return template.List()
+		if len(args) == 0 {
+			return template.List()
+		}
+		return template.ListRemote(args[0])
 	},
 }
 
-// Register the logic above with the CLI application
 func init() {
 	rootCmd.AddCommand(listCmd)
 }

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -18,15 +18,18 @@ var (
 )
 
 var scaffoldCmd = &cobra.Command{
-	Use:   "scaffold <owner/repo|path>",
+	Use:   "scaffold <owner/repo[/subpath]|path>",
 	Short: "Scaffold a project from a template",
 	Long: `Scaffold a project from a template.
 
-The template can be a GitHub repository (owner/repo) or a local directory path.
-If the template contains a terox.json manifest, you will be prompted for the
-declared variables and the template will be rendered into --output. If no
-manifest is present, the template files are copied as-is.`,
+The template can be a GitHub repository (owner/repo), a directory inside a
+GitHub repository (owner/repo/subpath, useful for template monorepos), or a
+local directory path. If the template contains a terox.json manifest, you
+will be prompted for the declared variables and the template will be
+rendered into --output. If no manifest is present, the template files are
+copied as-is.`,
 	Example: `  terox scaffold Weburz/simple-website-template --output ./my-site
+  terox scaffold weburz/terox-templates/nuxt-starter --output ./my-site
   terox scaffold ./my-local-template --output ./my-site
   terox scaffold Weburz/foo --set project_name=bar --set author=me --non-interactive`,
 	Args: cobra.ExactArgs(1),

--- a/docs/content/1.getting-started/3.quickstart.md
+++ b/docs/content/1.getting-started/3.quickstart.md
@@ -74,14 +74,26 @@ came from rendering `{{.project_name}}`.
 
 ## 3. Try it with a GitHub repository
 
-Any public GitHub repository works as a template:
+Any public GitHub repository works as a template. Weburz publishes its
+official templates as a monorepo at
+[`weburz/terox-templates`](https://github.com/weburz/terox-templates),
+where each top-level directory is a separate template you pick by
+appending its name to the ref:
 
 ```bash
-terox scaffold weburz/simple-website-template --output ./my-site
+terox scaffold weburz/terox-templates/npm-package --output ./my-package
 ```
 
-If the repository has a `terox.json` you will be prompted for its variables.
-If it does not, Terox simply copies the files as-is — a quick way to grab a
+To browse what the monorepo offers without leaving the terminal:
+
+```bash
+terox list weburz/terox-templates
+```
+
+A bare `owner/repo` ref (with no subpath) also works for single-template
+repositories such as `weburz/simple-website-template`. If the resolved
+template has a `terox.json` you will be prompted for its variables; if
+it does not, Terox simply copies the files as-is — a quick way to grab a
 clean snapshot of any repo without its git history.
 
 ## Where to next

--- a/docs/content/3.reference/1.cli.md
+++ b/docs/content/3.reference/1.cli.md
@@ -11,14 +11,14 @@ This page lists every subcommand Terox ships with. Run `terox <command>
 Render a template into an output directory.
 
 ```bash
-terox scaffold <owner/repo|path> [flags]
+terox scaffold <owner/repo[/subpath]|path> [flags]
 ```
 
 ### Arguments
 
-| Name                 | Description                                                                                  |
-| -------------------- | -------------------------------------------------------------------------------------------- |
-| `<owner/repo\|path>` | Either a public GitHub repository (`owner/repo`) or a local directory containing a template. |
+| Name                            | Description                                                                                                                                                                                                |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `<owner/repo[/subpath]\|path>` | A public GitHub repository (`owner/repo`), a directory inside one (`owner/repo/subpath`, e.g. `weburz/terox-templates/nuxt-starter` for template monorepos), or a local directory containing a template. |
 
 ### Flags
 
@@ -35,11 +35,11 @@ terox scaffold <owner/repo|path> [flags]
 # Interactive, from a local template
 terox scaffold ./templates/demo --output ./my-project
 
-# Non-interactive, from a GitHub repository
-terox scaffold weburz/simple-website-template \
-  --output ./my-site \
-  --set project_name=portfolio \
-  --set author="Sagar Kapoor" \
+# Non-interactive, from a template inside a GitHub monorepo
+terox scaffold weburz/terox-templates/npm-package \
+  --output ./my-package \
+  --set PackageName=@weburz/my-package \
+  --set AuthorName="Sagar Kapoor" \
   --non-interactive
 ```
 
@@ -84,14 +84,46 @@ The generated folder contains:
 
 ## `terox list`
 
-List templates that Terox has cached locally.
+List available templates — either from the local cache or from a remote
+GitHub repository.
+
+```bash
+terox list [owner/repo]
+```
+
+### Local cache
+
+With no argument, lists the `owner/repo` entries Terox has already
+downloaded. Templates are cached under `$XDG_DATA_HOME/terox/` (typically
+`~/.local/share/terox/`) the first time you scaffold from a remote source.
 
 ```bash
 terox list
 ```
 
-Templates are cached under `$XDG_DATA_HOME/terox/` (typically
-`~/.local/share/terox/`) the first time you scaffold from a remote source.
+### Remote repository
+
+Given a GitHub repo ref, lists every top-level directory at the root of
+that repo as a candidate template. If a directory contains a `terox.json`
+with a `description` field, the description is shown next to the name.
+Useful for monorepos like `weburz/terox-templates`.
+
+```bash
+terox list weburz/terox-templates
+```
+
+Example output:
+
+```
+weburz/terox-templates:
+  npm-package  Weburz-flavored TypeScript npm package starter…
+  nuxt-module  Weburz-flavored Nuxt 4 module starter…
+```
+
+The command uses the public GitHub API unauthenticated, which is rate-
+limited to 60 requests per hour per IP. Listing a `owner/repo` with a
+subpath (e.g. `owner/repo/foo`) is not supported — use `scaffold` for
+subpath refs instead.
 
 ## `terox clean`
 

--- a/internal/template/list.go
+++ b/internal/template/list.go
@@ -1,35 +1,205 @@
 package template
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"text/tabwriter"
 )
 
-/**
- * List - List all the locally available templates.
- *
- * Parameters:
- * None
- *
- * Returns:
- * A wrapped error if any is raised.
- */
+// List prints the templates already downloaded into the local cache.
+// The cache layout is "{templateDir}/{owner}/{repo}/...", so this walks
+// two levels deep to surface "owner/repo" entries.
 func List() error {
-	// Check if any template exists locally, if yes, list them to STDOUT
-	if templates, err := os.ReadDir(templateDir); err != nil {
-		return fmt.Errorf(
-			"failed to read the contents of %s directory: %w",
-			templateDir,
-			err,
-		)
-	} else if len(templates) != 0 {
-		fmt.Printf("Available Templates:\n")
-		for _, template := range templates {
-			if template.IsDir() {
-				fmt.Printf("%s\n", template.Name())
+	owners, err := os.ReadDir(templateDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Println("No templates cached locally.")
+			return nil
+		}
+		return fmt.Errorf("read %s: %w", templateDir, err)
+	}
+
+	var refs []string
+	for _, owner := range owners {
+		if !owner.IsDir() {
+			continue
+		}
+		repos, err := os.ReadDir(filepath.Join(templateDir, owner.Name()))
+		if err != nil {
+			continue
+		}
+		for _, repo := range repos {
+			if !repo.IsDir() {
+				continue
 			}
+			refs = append(refs, owner.Name()+"/"+repo.Name())
 		}
 	}
 
+	if len(refs) == 0 {
+		fmt.Println("No templates cached locally.")
+		return nil
+	}
+
+	sort.Strings(refs)
+	fmt.Println("Cached templates:")
+	for _, r := range refs {
+		fmt.Printf("  %s\n", r)
+	}
 	return nil
+}
+
+// ListRemote prints the templates available at the root of a remote
+// GitHub repository. The ref must be of the form "owner/repo"; listing
+// a subpath is not supported. Each top-level directory is treated as a
+// candidate template; a terox.json inside it (if present) supplies the
+// description shown in the output.
+func ListRemote(ref string) error {
+	owner, repo, subpath, err := splitRef(ref)
+	if err != nil {
+		return err
+	}
+	if subpath != "" {
+		return fmt.Errorf("listing a subpath is not supported; use just 'owner/repo'")
+	}
+
+	dirs, err := fetchRepoTopLevelDirs(owner, repo)
+	if err != nil {
+		return err
+	}
+	dirs = filterListableDirs(dirs)
+	if len(dirs) == 0 {
+		fmt.Printf("No templates found in %s/%s.\n", owner, repo)
+		return nil
+	}
+
+	sort.Strings(dirs)
+	entries := make([]catalogueEntry, 0, len(dirs))
+	for _, d := range dirs {
+		desc, err := fetchTemplateDescription(owner, repo, d)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: %v\n", err)
+		}
+		entries = append(entries, catalogueEntry{Name: d, Description: desc})
+	}
+
+	printCatalogue(os.Stdout, owner+"/"+repo, entries)
+	return nil
+}
+
+type catalogueEntry struct {
+	Name        string
+	Description string
+}
+
+// nonTemplateDirs is the small denylist of repo-root directories that
+// are almost never templates and would otherwise pollute the listing.
+var nonTemplateDirs = map[string]struct{}{
+	".github":      {},
+	".vscode":      {},
+	"docs":         {},
+	"node_modules": {},
+}
+
+// filterListableDirs drops repo-root entries that are conventionally
+// not templates: dot-prefixed dirs, underscore-prefixed dirs, and a
+// small denylist of common non-template folders.
+func filterListableDirs(dirs []string) []string {
+	out := make([]string, 0, len(dirs))
+	for _, d := range dirs {
+		if strings.HasPrefix(d, ".") || strings.HasPrefix(d, "_") {
+			continue
+		}
+		if _, skip := nonTemplateDirs[d]; skip {
+			continue
+		}
+		out = append(out, d)
+	}
+	return out
+}
+
+func fetchRepoTopLevelDirs(owner, repo string) ([]string, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/contents", owner, repo)
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("list contents of %s/%s: %w", owner, repo, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+	case http.StatusNotFound:
+		return nil, fmt.Errorf("repository %s/%s not found", owner, repo)
+	case http.StatusForbidden:
+		return nil, fmt.Errorf("list contents of %s/%s: GitHub API rate limit reached (HTTP 403)", owner, repo)
+	default:
+		return nil, fmt.Errorf("list contents of %s/%s: HTTP %d", owner, repo, resp.StatusCode)
+	}
+
+	var items []struct {
+		Name string `json:"name"`
+		Type string `json:"type"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&items); err != nil {
+		return nil, fmt.Errorf("parse contents response for %s/%s: %w", owner, repo, err)
+	}
+
+	var dirs []string
+	for _, it := range items {
+		if it.Type == "dir" {
+			dirs = append(dirs, it.Name)
+		}
+	}
+	return dirs, nil
+}
+
+// fetchTemplateDescription returns the description from a template's
+// terox.json. A missing manifest is not an error — the template simply
+// has no description.
+func fetchTemplateDescription(owner, repo, dir string) (string, error) {
+	url := fmt.Sprintf(
+		"https://raw.githubusercontent.com/%s/%s/HEAD/%s/%s",
+		owner, repo, dir, ManifestFilename,
+	)
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("fetch manifest for %s: %w", dir, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return "", nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("fetch manifest for %s: HTTP %d", dir, resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read manifest for %s: %w", dir, err)
+	}
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return "", fmt.Errorf("parse manifest for %s: %w", dir, err)
+	}
+	return m.Description, nil
+}
+
+func printCatalogue(w io.Writer, ref string, entries []catalogueEntry) {
+	_, _ = fmt.Fprintf(w, "%s:\n", ref)
+	tw := tabwriter.NewWriter(w, 2, 2, 2, ' ', 0)
+	for _, e := range entries {
+		if e.Description != "" {
+			_, _ = fmt.Fprintf(tw, "  %s\t%s\n", e.Name, e.Description)
+		} else {
+			_, _ = fmt.Fprintf(tw, "  %s\t\n", e.Name)
+		}
+	}
+	_ = tw.Flush()
 }

--- a/internal/template/list_test.go
+++ b/internal/template/list_test.go
@@ -1,0 +1,98 @@
+package template
+
+import (
+	"bytes"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestFilterListableDirs(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "passes plain template dirs",
+			in:   []string{"npm-package", "nuxt-module", "simple-website"},
+			want: []string{"npm-package", "nuxt-module", "simple-website"},
+		},
+		{
+			name: "drops dot-prefixed and underscore-prefixed",
+			in:   []string{"a", ".github", "_meta", "b"},
+			want: []string{"a", "b"},
+		},
+		{
+			name: "drops common non-template dirs",
+			in:   []string{"docs", "node_modules", ".vscode", "nuxt-module"},
+			want: []string{"nuxt-module"},
+		},
+		{
+			name: "empty input gives empty output",
+			in:   nil,
+			want: []string{},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := filterListableDirs(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got %v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPrintCatalogue(t *testing.T) {
+	var buf bytes.Buffer
+	printCatalogue(&buf, "weburz/terox-templates", []catalogueEntry{
+		{Name: "npm-package", Description: "TS lib starter"},
+		{Name: "nuxt-module", Description: "Nuxt 4 module starter"},
+		{Name: "no-desc", Description: ""},
+	})
+
+	out := buf.String()
+
+	if !strings.HasPrefix(out, "weburz/terox-templates:\n") {
+		t.Errorf("missing header in output:\n%s", out)
+	}
+	for _, want := range []string{"npm-package", "TS lib starter", "nuxt-module", "Nuxt 4 module starter", "no-desc"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+
+	// Verify the name column is padded so descriptions align: the
+	// substring between "npm-package" and "TS lib" must be the same
+	// width as the substring between "nuxt-module" and "Nuxt 4".
+	padAfter := func(name string) int {
+		i := strings.Index(out, name)
+		if i < 0 {
+			t.Fatalf("name %q not found in output", name)
+		}
+		rest := out[i+len(name):]
+		end := strings.IndexFunc(rest, func(r rune) bool { return r != ' ' })
+		return end
+	}
+	if padAfter("npm-package") != padAfter("nuxt-module") {
+		t.Errorf("name column not aligned between entries:\n%s", out)
+	}
+}
+
+func TestListRemote_RejectsSubpath(t *testing.T) {
+	err := ListRemote("weburz/terox-templates/npm-package")
+	if err == nil {
+		t.Fatal("expected error when ref includes a subpath")
+	}
+	if !strings.Contains(err.Error(), "subpath") {
+		t.Errorf("error should mention subpath, got %q", err.Error())
+	}
+}
+
+func TestListRemote_RejectsInvalidRef(t *testing.T) {
+	err := ListRemote("nofslash")
+	if err == nil {
+		t.Fatal("expected error for malformed ref")
+	}
+}

--- a/internal/template/scaffold.go
+++ b/internal/template/scaffold.go
@@ -14,57 +14,118 @@ import (
 
 var templateDir = filepath.Join(xdg.DataHome, "terox")
 
-// Cache resolves a "owner/repo" string to a local template directory,
-// downloading and extracting the zipball if not already cached.
-// When refresh is true, any existing cached copy is removed first so the
-// template is re-downloaded.
-// Returns the absolute path to the cached template root.
-func Cache(repo string, refresh bool) (string, error) {
-	owner, repository, err := splitRepo(repo)
+// Cache resolves a template ref to a local directory, downloading and
+// extracting the zipball if not already cached. The ref is either
+// "owner/repo" (the repo root is the template) or "owner/repo/subpath"
+// (a directory inside the repo is the template — useful for monorepos
+// like weburz/terox-templates).
+//
+// When refresh is true, any existing cached copy of the repo is removed
+// first so the template is re-downloaded.
+// Returns the absolute path to the template directory (the repo root,
+// or the resolved subpath within it).
+func Cache(ref string, refresh bool) (string, error) {
+	owner, repository, subpath, err := splitRef(ref)
 	if err != nil {
 		return "", err
 	}
 
+	repoRef := owner + "/" + repository
 	// GitHub lowercases owner/repo in zipball folder names, so the cached
 	// path is the lowercased version.
 	dir := filepath.Join(templateDir, strings.ToLower(owner), strings.ToLower(repository))
 
 	if refresh {
 		if err := os.RemoveAll(dir); err != nil {
-			return "", fmt.Errorf("refresh cache for %s: %w", repo, err)
+			return "", fmt.Errorf("refresh cache for %s: %w", repoRef, err)
 		}
-	} else {
+	}
+
+	cacheHit := false
+	if !refresh {
 		if _, err := os.Stat(dir); err == nil {
-			return dir, nil
+			cacheHit = true
 		} else if !os.IsNotExist(err) {
 			return "", fmt.Errorf("stat template path %s: %w", dir, err)
 		}
 	}
 
-	if refresh {
-		fmt.Printf("Refreshing cache; downloading %s...\n", repo)
-	} else {
-		fmt.Printf("Template not found locally; downloading %s...\n", repo)
-	}
-	zipPath, err := downloadTemplate(repo)
-	if err != nil {
-		return "", err
-	}
-	defer func() { _ = os.Remove(zipPath) }()
+	if !cacheHit {
+		if refresh {
+			fmt.Printf("Refreshing cache; downloading %s...\n", repoRef)
+		} else {
+			fmt.Printf("Template not found locally; downloading %s...\n", repoRef)
+		}
+		zipPath, err := downloadTemplate(repoRef)
+		if err != nil {
+			return "", err
+		}
+		defer func() { _ = os.Remove(zipPath) }()
 
-	finalDest, err := extractTemplate(zipPath, templateDir)
-	if err != nil {
-		return "", err
+		if err := extractTemplate(zipPath, dir); err != nil {
+			return "", err
+		}
 	}
-	return finalDest, nil
+
+	return resolveSubpath(dir, subpath, repoRef)
 }
 
-func splitRepo(repo string) (string, string, error) {
-	parts := strings.SplitN(repo, "/", 2)
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return "", "", fmt.Errorf("template ref must be 'owner/repo', got %q", repo)
+// splitRef parses a template ref of the form "owner/repo" or
+// "owner/repo/subpath". The subpath, if present, must be a relative,
+// forward-slash path with no empty, "." or ".." segments.
+func splitRef(ref string) (owner, repo, subpath string, err error) {
+	parts := strings.SplitN(ref, "/", 3)
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", "", fmt.Errorf("template ref must be 'owner/repo' or 'owner/repo/subpath', got %q", ref)
 	}
-	return parts[0], parts[1], nil
+	owner = parts[0]
+	repo = parts[1]
+	if len(parts) == 3 {
+		subpath = parts[2]
+		if subpath == "" {
+			return "", "", "", fmt.Errorf("template ref subpath must not be empty, got %q", ref)
+		}
+		if err := validateSubpath(subpath); err != nil {
+			return "", "", "", fmt.Errorf("invalid subpath in %q: %w", ref, err)
+		}
+	}
+	return owner, repo, subpath, nil
+}
+
+// validateSubpath rejects subpaths that escape the repo root or contain
+// empty/dot segments. The input is always forward-slash separated since
+// it comes from a user-supplied ref, not a filesystem path.
+func validateSubpath(p string) error {
+	if strings.HasPrefix(p, "/") {
+		return fmt.Errorf("subpath must be relative")
+	}
+	for _, seg := range strings.Split(p, "/") {
+		switch seg {
+		case "":
+			return fmt.Errorf("subpath must not contain empty segments")
+		case ".", "..":
+			return fmt.Errorf("subpath segment %q is not allowed", seg)
+		}
+	}
+	return nil
+}
+
+func resolveSubpath(root, subpath, repoRef string) (string, error) {
+	if subpath == "" {
+		return root, nil
+	}
+	dest := filepath.Join(root, filepath.FromSlash(subpath))
+	info, err := os.Stat(dest)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("subpath %q not found in %s", subpath, repoRef)
+		}
+		return "", fmt.Errorf("stat subpath %s: %w", dest, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("subpath %q in %s is not a directory", subpath, repoRef)
+	}
+	return dest, nil
 }
 
 func downloadTemplate(repo string) (string, error) {
@@ -95,10 +156,16 @@ func downloadTemplate(repo string) (string, error) {
 	return tempFile.Name(), nil
 }
 
-func extractTemplate(zipfile, dest string) (string, error) {
+// extractTemplate unzips a GitHub zipball into dest. GitHub zipballs
+// always have a single top-level folder of the form
+// "{owner}-{repo}-{sha-prefix}"; that folder is detected dynamically and
+// stripped from each entry's path. dest is supplied by the caller because
+// the folder name cannot be reliably split back into owner/repo when
+// either contains hyphens (e.g. "weburz-terox-templates-abc123").
+func extractTemplate(zipfile, dest string) error {
 	r, err := zip.OpenReader(zipfile)
 	if err != nil {
-		return "", fmt.Errorf("open zip: %w", err)
+		return fmt.Errorf("open zip: %w", err)
 	}
 	defer func() { _ = r.Close() }()
 
@@ -111,27 +178,19 @@ func extractTemplate(zipfile, dest string) (string, error) {
 		}
 	}
 	if topLevelFolder == "" {
-		return "", fmt.Errorf("failed to detect the top-level directory in the archive")
+		return fmt.Errorf("failed to detect the top-level directory in the archive")
 	}
 
-	parts := strings.SplitN(topLevelFolder, "-", 3)
-	if len(parts) < 2 {
-		return "", fmt.Errorf("unexpected folder structure: %s", topLevelFolder)
-	}
-	owner := parts[0]
-	repo := parts[1]
-
-	finalDest := filepath.Join(dest, owner, repo)
-	if err := os.MkdirAll(finalDest, 0o755); err != nil {
-		return "", fmt.Errorf("create destination directory: %w", err)
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		return fmt.Errorf("create destination directory: %w", err)
 	}
 
 	for _, f := range r.File {
-		if err := extractOne(f, topLevelFolder, finalDest); err != nil {
-			return "", err
+		if err := extractOne(f, topLevelFolder, dest); err != nil {
+			return err
 		}
 	}
-	return finalDest, nil
+	return nil
 }
 
 func extractOne(f *zip.File, topLevelFolder, finalDest string) error {

--- a/internal/template/scaffold_test.go
+++ b/internal/template/scaffold_test.go
@@ -7,36 +7,99 @@ import (
 	"testing"
 )
 
-func TestSplitRepo(t *testing.T) {
+func TestSplitRef(t *testing.T) {
 	tests := []struct {
-		in        string
-		wantOwner string
-		wantRepo  string
-		wantErr   bool
+		in          string
+		wantOwner   string
+		wantRepo    string
+		wantSubpath string
+		wantErr     bool
 	}{
-		{"foo/bar", "foo", "bar", false},
-		{"Weburz/simple-website-template", "Weburz", "simple-website-template", false},
-		{"foo/bar/baz", "foo", "bar/baz", false}, // SplitN keeps trailing slashes in repo
-		{"", "", "", true},
-		{"nofslash", "", "", true},
-		{"/bar", "", "", true},
-		{"foo/", "", "", true},
-		{"/", "", "", true},
+		{"foo/bar", "foo", "bar", "", false},
+		{"Weburz/simple-website-template", "Weburz", "simple-website-template", "", false},
+		{"weburz/terox-templates/nuxt-starter", "weburz", "terox-templates", "nuxt-starter", false},
+		{"weburz/terox-templates/group/nested", "weburz", "terox-templates", "group/nested", false},
+		{"", "", "", "", true},
+		{"nofslash", "", "", "", true},
+		{"/bar", "", "", "", true},
+		{"foo/", "", "", "", true},
+		{"/", "", "", "", true},
+		{"foo/bar/", "", "", "", true},       // trailing slash → empty subpath
+		{"foo/bar//baz", "", "", "", true},   // empty segment in subpath
+		{"foo/bar/..", "", "", "", true},     // escape attempt
+		{"foo/bar/../etc", "", "", "", true}, // escape attempt
+		{"foo/bar/./baz", "", "", "", true},  // dot segment
+		{"foo/bar//", "", "", "", true},      // empty segment
 	}
 	for _, tc := range tests {
 		t.Run(tc.in, func(t *testing.T) {
-			owner, repo, err := splitRepo(tc.in)
+			owner, repo, subpath, err := splitRef(tc.in)
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("err: got %v wantErr=%v", err, tc.wantErr)
 			}
 			if tc.wantErr {
 				return
 			}
-			if owner != tc.wantOwner || repo != tc.wantRepo {
-				t.Errorf("got (%q, %q) want (%q, %q)", owner, repo, tc.wantOwner, tc.wantRepo)
+			if owner != tc.wantOwner || repo != tc.wantRepo || subpath != tc.wantSubpath {
+				t.Errorf("got (%q, %q, %q) want (%q, %q, %q)",
+					owner, repo, subpath, tc.wantOwner, tc.wantRepo, tc.wantSubpath)
 			}
 		})
 	}
+}
+
+func TestResolveSubpath(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "nuxt-starter", "pages"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "loose-file.txt"), []byte("hi"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	t.Run("empty subpath returns root", func(t *testing.T) {
+		got, err := resolveSubpath(root, "", "owner/repo")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if got != root {
+			t.Errorf("got %q want %q", got, root)
+		}
+	})
+
+	t.Run("existing directory resolves", func(t *testing.T) {
+		got, err := resolveSubpath(root, "nuxt-starter", "owner/repo")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		want := filepath.Join(root, "nuxt-starter")
+		if got != want {
+			t.Errorf("got %q want %q", got, want)
+		}
+	})
+
+	t.Run("nested directory resolves", func(t *testing.T) {
+		got, err := resolveSubpath(root, "nuxt-starter/pages", "owner/repo")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		want := filepath.Join(root, "nuxt-starter", "pages")
+		if got != want {
+			t.Errorf("got %q want %q", got, want)
+		}
+	})
+
+	t.Run("missing subpath errors", func(t *testing.T) {
+		if _, err := resolveSubpath(root, "does-not-exist", "owner/repo"); err == nil {
+			t.Fatal("expected error for missing subpath")
+		}
+	})
+
+	t.Run("file subpath errors", func(t *testing.T) {
+		if _, err := resolveSubpath(root, "loose-file.txt", "owner/repo"); err == nil {
+			t.Fatal("expected error when subpath points to a file")
+		}
+	})
 }
 
 // makeFakeZip builds a zip that mimics a GitHub zipball: one top-level
@@ -66,25 +129,19 @@ func makeFakeZip(t *testing.T, topFolder string, files map[string]string) string
 	return f.Name()
 }
 
-func TestExtractTemplate_LowercasesOwnerRepo(t *testing.T) {
-	dest := t.TempDir()
+func TestExtractTemplate_StripsTopLevelFolder(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "weburz", "crisp")
 	// GitHub's zipballs name the top folder like "weburz-crisp-abc123def".
 	zipPath := makeFakeZip(t, "weburz-crisp-abc123def", map[string]string{
 		"README.md":      "hello\n",
 		"sub/nested.txt": "nested body\n",
 	})
 
-	finalDest, err := extractTemplate(zipPath, dest)
-	if err != nil {
+	if err := extractTemplate(zipPath, dest); err != nil {
 		t.Fatalf("extractTemplate: %v", err)
 	}
 
-	wantDest := filepath.Join(dest, "weburz", "crisp")
-	if finalDest != wantDest {
-		t.Errorf("finalDest: got %q want %q", finalDest, wantDest)
-	}
-
-	readme, err := os.ReadFile(filepath.Join(finalDest, "README.md"))
+	readme, err := os.ReadFile(filepath.Join(dest, "README.md"))
 	if err != nil {
 		t.Fatalf("read README: %v", err)
 	}
@@ -92,7 +149,7 @@ func TestExtractTemplate_LowercasesOwnerRepo(t *testing.T) {
 		t.Errorf("README content: got %q", readme)
 	}
 
-	nested, err := os.ReadFile(filepath.Join(finalDest, "sub", "nested.txt"))
+	nested, err := os.ReadFile(filepath.Join(dest, "sub", "nested.txt"))
 	if err != nil {
 		t.Fatalf("read nested: %v", err)
 	}
@@ -101,13 +158,30 @@ func TestExtractTemplate_LowercasesOwnerRepo(t *testing.T) {
 	}
 }
 
-func TestExtractTemplate_RejectsBadTopFolder(t *testing.T) {
-	dest := t.TempDir()
-	// Top folder without the expected "owner-repo-sha" structure.
-	zipPath := makeFakeZip(t, "weirdfolder", map[string]string{
-		"file.txt": "hi\n",
+func TestExtractTemplate_HyphenatedRepoName(t *testing.T) {
+	// Regression: previously the destination was guessed by parsing the
+	// top-level folder name with strings.SplitN("-", 3), which mapped
+	// "weburz-terox-templates-abc123" to owner=weburz,repo=terox. The
+	// caller now controls the destination, so hyphenated repo names
+	// extract correctly.
+	dest := filepath.Join(t.TempDir(), "weburz", "terox-templates")
+	zipPath := makeFakeZip(t, "weburz-terox-templates-abc123def", map[string]string{
+		"npm-package/terox.json": `{"name":"npm-package"}`,
+		"nuxt-module/terox.json": `{"name":"nuxt-module"}`,
+		"README.md":              "monorepo readme\n",
 	})
-	if _, err := extractTemplate(zipPath, dest); err == nil {
-		t.Fatal("expected error for malformed top folder")
+
+	if err := extractTemplate(zipPath, dest); err != nil {
+		t.Fatalf("extractTemplate: %v", err)
+	}
+
+	for _, p := range []string{
+		"README.md",
+		filepath.Join("npm-package", "terox.json"),
+		filepath.Join("nuxt-module", "terox.json"),
+	} {
+		if _, err := os.Stat(filepath.Join(dest, p)); err != nil {
+			t.Errorf("expected %s to exist after extract: %v", p, err)
+		}
 	}
 }


### PR DESCRIPTION
## Description

Extend Terox's remote template ref parser to accept `owner/repo/subpath`, so a single GitHub repository can host multiple templates (e.g. `weburz/terox-templates/npm-package`). The zipball is cached once per repo and the requested subdirectory is resolved on every scaffold call. Also fixes a pre-existing bug in `extractTemplate` where hyphenated repo names were mis-routed in the local cache.

## Modifications

- **Ref parsing.** Replaced `splitRepo` with `splitRef`, which returns `(owner, repo, subpath, error)`. Rejects empty segments, `.` / `..` segments, and absolute paths to prevent escapes outside the cached repo root.
- **Cache resolution.** `template.Cache` now reuses one zipball per `owner/repo`, so two templates from the same monorepo share a single download. Subpath resolution is applied on both cache-miss and cache-hit paths (the previous shape would have returned the repo root on cache hits regardless of subpath).
- **Hyphen-safe extraction.** `extractTemplate` no longer guesses owner/repo by splitting the zipball's top-level folder name on `-`. That heuristic broke for any repo whose name contained a hyphen (the regression that initially surfaced with `terox-templates`). The destination is now supplied by the caller, which already knows the parsed ref.
- **Tests.** `TestSplitRef` covers happy paths and every rejection case (empty owner/repo, trailing slash, empty segments, `.` / `..`, absolute paths). New `TestResolveSubpath` covers empty / existing / nested / missing / file-not-dir cases. `TestExtractTemplate_HyphenatedRepoName` is a regression test for the extraction fix.
- **CLI surface.** `terox scaffold` usage updated to `<owner/repo[/subpath]|path>`; help text, long description, and examples reflect the new ref form.
- **Docs.** README, quickstart, and CLI reference updated so the canonical GitHub example points at `weburz/terox templates/npm-package`. The fallback (`owner/repo` for single-template repos like `weburz/simple-website-template`) is still documented.

### Fixed issue(s)

Closes #115